### PR TITLE
fix pipe leak, support redirects

### DIFF
--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -203,7 +203,8 @@ sub _stdout_callback {
     my $read = $stdout_read->sysread(my $b, CHUNK_SIZE, 0);
 
     if(!$read) {
-      Mojo::IOLoop->singleton->reactor->watch($stdout_read, 0, 0);
+      Mojo::IOLoop->singleton->reactor->remove($stdout_read);
+      $c->stash('cgi.stdin')->handle->close;
       unlink $c->stash('cgi.stdin')->path;
       waitpid $c->stash('cgi.pid'), 0;
       $c->stash('cgi.cb')->();
@@ -221,7 +222,7 @@ sub _stdout_callback {
       $c->res->parse($headers);
     }
     else {
-      $c->res->code(200);
+      $c->res->code($headers =~ /Location:/ ? 302 : 200);
       $c->res->parse($c->res->get_start_line_chunk(0) .$headers);
     }
 

--- a/t/cgi-bin/redirect.pl
+++ b/t/cgi-bin/redirect.pl
@@ -1,0 +1,4 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+print "Location: http://somewhereelse.com\n\r\n\r";

--- a/t/post.t
+++ b/t/post.t
@@ -27,4 +27,14 @@ else {
   ok $pid, 'could not get pid';
 }
 
+# FIXME? possibly not the best way to test if there is a pipe leak
+if (-d "/proc/$$/fd") {
+  my $pipes = grep { defined $_ ? /pipe:/ : undef }
+    map { readlink("/proc/$$/fd/".(split '/')[-1]) }
+      glob "/proc/$$/fd/*";
+
+  note "pipes:$pipes";
+  ok( !($pipes % 2),'no leaky pipes');
+}
+
 done_testing;

--- a/t/redirect.t
+++ b/t/redirect.t
@@ -1,0 +1,20 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::Mojo;
+
+plan skip_all => 't/cgi-bin/redirect.pl' unless -x 't/cgi-bin/redirect.pl';
+
+{
+  use Mojolicious::Lite;
+  plugin CGI => [ '/redirect' => 't/cgi-bin/redirect.pl' ];
+}
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/redirect', {} )
+  ->status_is(302)
+  ->header_is('Location' => 'http://somewhereelse.com')
+  ->content_is('');
+
+done_testing;


### PR DESCRIPTION
rather than pausing the reactor by calling watch ($fh,0,0) remove
it entirely as the child process will exit and we need the pipe to
close otherwise we will hit the limit on open files when running
the plugin as part of a persistent environment (Mojo::IOLoop will
be in the parent, so having it pause means the handle doesn't go
out of scope).

add a test for the above, possibly not the best way to check the
number of open pipes is as expected, but "it works on my machine"

also explicitly close the cgi.stdin handle before unlinking the
path it points to

support redirects in cgi scripts that send a "Location: " header
by returning a 302 response code so the browser correctly renders
the output. this fixes an issue where you the browser will render
the content of the cgi script as plain text as there will be two
sets of headers. add a test for this
