### PR TITLE
resolve #11 - fix multipart test content length value

### DIFF
--- a/t/multipart.t
+++ b/t/multipart.t
@@ -23,7 +23,7 @@ $t->status_is(200);
 
 $t->content_like(qr{^\d+
 === multipart/form-data; boundary=(\w+)
-=== 337
+=== \d+
 --- --\1\r
 --- Content-Disposition: form-data; name="mytext"; filename="foo\.txt"\r
 --- \r


### PR DESCRIPTION
change this to a \d+ check rather than an explicit check since this
may change. this appears to be caused by a recent change in the core
Mojolicious code: 34c7b4f2d16244c641c27bee54112dff18e94f38 but the
commit message doesn't tell us _why_ 2 extra bytes were added to the
content_length value (it seems to be due to an extra \x0d\x0a at the
end of the boundary definition)
