### PR TITLE
Parsing of Status Codes

### DIFF
--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -288,8 +288,8 @@ sub _stdout_cb {
     $buf .= $chunk;
     $buf =~ s/^(.*?\x0a\x0d?\x0a\x0d?)//s or return;    # false until all headers has been read from the CGI script
     $headers = $1;
-    if ($headers =~ /^HTTP\/\d\.\d (\d\d\d)?/) {
-      $c->res->code($1) if $1;
+    if ($headers =~ /^HTTP/) {
+      $c->res->code($1) if $headers =~ m!^HTTP/\d\.\d (\d\d\d)!;
       $c->res->parse($headers);
     }
     else {

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -287,7 +287,8 @@ sub _stdout_cb {
       $c->res->parse($headers);
     }
     else {
-      $c->res->code($headers =~ /Location:/ ? 302 : 200);
+      $c->res->code($1) if $headers =~ /^Status: (\d\d\d)/m;
+      $c->res->code($headers =~ /Location:/ ? 302 : 200) unless $c->res->code;
       $c->res->parse($c->res->get_start_line_chunk(0) . $headers);
     }
     $c->write($buf) if length $buf;

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -128,13 +128,13 @@ sub emulate_environment {
     %{$self->env},
     CONTENT_LENGTH => $content_length        || 0,
     CONTENT_TYPE   => $headers->content_type || '',
-    GATEWAY_INTERFACE => 'CGI/1.1',
-    HTTP_COOKIE       => $headers->cookie || '',
-    HTTP_HOST         => $headers->host || '',
-    HTTP_REFERER      => $headers->referrer || '',
-    HTTP_USER_AGENT   => $headers->user_agent || '',
-    HTTP_IF_NONE_MATCH=> $headers->if_none_match || '',
-    HTTPS             => $req->is_secure ? 'YES' : 'NO',
+    GATEWAY_INTERFACE  => 'CGI/1.1',
+    HTTP_COOKIE        => $headers->cookie || '',
+    HTTP_HOST          => $headers->host || '',
+    HTTP_REFERER       => $headers->referrer || '',
+    HTTP_USER_AGENT    => $headers->user_agent || '',
+    HTTP_IF_NONE_MATCH => $headers->if_none_match || '',
+    HTTPS              => $req->is_secure ? 'YES' : 'NO',
 
     #PATH => $req->url->path,
     PATH_INFO => '/' . ($c->stash('path_info') || ''),
@@ -177,7 +177,11 @@ sub register {
     $self->{script} = shift @$args;
   }
   elsif ($args->{support_semicolon_in_query_string}) {
-    $app->hook(before_dispatch => sub { $_[0]->stash('cgi.query_string' => $_[0]->req->url->query->to_string); });
+    $app->hook(
+      before_dispatch => sub {
+        $_[0]->stash('cgi.query_string' => $_[0]->req->url->query->to_string);
+      }
+    );
     return;
   }
   else {
@@ -214,14 +218,16 @@ sub register {
         $| = 1;
         select STDOUT;
         $| = 1;
-	if ($self->{run}) {
-	  Mojo::IOLoop->reset; # clean up
-	  $self->{run}->();
-	  exit;
-	} else {
-	  { exec $self->{script} }
-	  die "Could not execute $self->{script}: $!";
-	}
+
+        if ($self->{run}) {
+          Mojo::IOLoop->reset;    # clean up
+          $self->{run}->();
+          exit;
+        }
+        else {
+          { exec $self->{script} }
+          die "Could not execute $self->{script}: $!";
+        }
       }
       $log->debug("[CGI:$name:$pid] START $self->{script}");
       $pids->{$pid} = $name;

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -281,15 +281,14 @@ sub _stdout_cb {
     $buf .= $chunk;
     $buf =~ s/^(.*?\x0a\x0d?\x0a\x0d?)//s or return;    # false until all headers has been read from the CGI script
     $headers = $1;
-
-    if ($headers =~ /^HTTP/) {
+    if ($headers =~ /^HTTP(?: (\d\d\d))?/) {
+      $c->res->code($1) if $1;
       $c->res->parse($headers);
     }
     else {
       $c->res->code($headers =~ /Location:/ ? 302 : 200);
       $c->res->parse($c->res->get_start_line_chunk(0) . $headers);
     }
-
     $c->write($buf) if length $buf;
   };
 }

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -133,6 +133,7 @@ sub emulate_environment {
     HTTP_HOST         => $headers->host || '',
     HTTP_REFERER      => $headers->referrer || '',
     HTTP_USER_AGENT   => $headers->user_agent || '',
+    HTTP_IF_NONE_MATCH=> $headers->if_none_match || '',
     HTTPS             => $req->is_secure ? 'YES' : 'NO',
 
     #PATH => $req->url->path,

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -289,7 +289,7 @@ sub _stdout_cb {
     $buf =~ s/^(.*?\x0a\x0d?\x0a\x0d?)//s or return;    # false until all headers has been read from the CGI script
     $headers = $1;
     if ($headers =~ /^HTTP/) {
-      $c->res->code($1) if $headers =~ m!^HTTP/\d\.\d (\d\d\d)!;
+      $c->res->code($1) if $headers =~ m!^HTTP (\d\d\d)!;    # borked CGI response if SERVER_PROTOCOL has no version
       $c->res->parse($headers);
     }
     else {

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -288,7 +288,7 @@ sub _stdout_cb {
     $buf .= $chunk;
     $buf =~ s/^(.*?\x0a\x0d?\x0a\x0d?)//s or return;    # false until all headers has been read from the CGI script
     $headers = $1;
-    if ($headers =~ /^HTTP(?: (\d\d\d))?/) {
+    if ($headers =~ /^HTTP (\d\d\d)?/) {
       $c->res->code($1) if $1;
       $c->res->parse($headers);
     }

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -288,7 +288,7 @@ sub _stdout_cb {
     $buf .= $chunk;
     $buf =~ s/^(.*?\x0a\x0d?\x0a\x0d?)//s or return;    # false until all headers has been read from the CGI script
     $headers = $1;
-    if ($headers =~ /^HTTP (\d\d\d)?/) {
+    if ($headers =~ /^HTTP\/\d\.\d (\d\d\d)?/) {
       $c->res->code($1) if $1;
       $c->res->parse($headers);
     }

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -204,7 +204,6 @@ sub register {
       defined($pid = fork) or die "[CGI] Could not fork $name: $!";
 
       unless ($pid) {
-	Mojo::IOLoop->reset if $self->{run}; # clean up unless CGI script is started with exec()
         my @STDERR = @stderr ? ('>&', fileno $stderr[WRITE]) : ('>>', $self->{errlog});
         warn "[CGI:$name:$$] <<< (@{[$stdin->slurp]})\n" if DEBUG;
         %ENV = $self->emulate_environment($c);
@@ -216,6 +215,7 @@ sub register {
         select STDOUT;
         $| = 1;
 	if ($self->{run}) {
+	  Mojo::IOLoop->reset; # clean up
 	  $self->{run}->();
 	  exit;
 	} else {

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -219,9 +219,9 @@ sub register {
         select STDOUT;
         $| = 1;
 
-        if ($self->{run}) {
+        if (my $code = $self->{run}) {
           Mojo::IOLoop->reset;    # clean up
-          $self->{run}->();
+          $code->();
           exit;
         }
         else {

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -221,7 +221,7 @@ sub register {
 
         if (my $code = $self->{run}) {
           Mojo::IOLoop->reset;    # clean up
-          $code->();
+          $code->($c);
           exit;
         }
         else {

--- a/t/cgi-bin/not-found.pl
+++ b/t/cgi-bin/not-found.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+print "Status: 404 Not Found\r\n";
+print "Content-Type: text/html; charset=ISO-8859-1\r\n";
+print "\r\n";
+print "<body><p>This page is missing\n";

--- a/t/cgi-bin/not-modified.pl
+++ b/t/cgi-bin/not-modified.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+print "Status: 304 Not Modified\r\n";
+print "X-Test: if-none-match seen: $ENV{HTTP_IF_NONE_MATCH}\r\n";
+print "\r\n";

--- a/t/cgi-bin/nph-borked.pl
+++ b/t/cgi-bin/nph-borked.pl
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+# When SERVER_PROTOCOL is set to "HTTP", the CGI module will just print HTTP and
+# no version!
+print "HTTP 403 Payment Required\r\n";
+print "Content-Type: text/html; charset=ISO-8859-1\r\n";
+print "\r\n";
+print "<body><p>This is the borked paywall.\n";

--- a/t/cgi-bin/nph.pl
+++ b/t/cgi-bin/nph.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+print "HTTP/1.1 403 Payment Required\r\n";
+print "Content-Type: text/html; charset=ISO-8859-1\r\n";
+print "\r\n";
+print "<body><p>This is the paywall.\n";

--- a/t/not-found.t
+++ b/t/not-found.t
@@ -1,0 +1,19 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::Mojo;
+
+plan skip_all => 't/cgi-bin/not-found.pl' unless -x 't/cgi-bin/not-found.pl';
+
+{
+  use Mojolicious::Lite;
+  plugin CGI => [ '/not-found' => 't/cgi-bin/not-found.pl' ];
+}
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/not-found', {} )
+  ->status_is(404)
+  ->content_like(qr'This page is missing');
+
+done_testing;

--- a/t/not-modified.t
+++ b/t/not-modified.t
@@ -1,0 +1,19 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::Mojo;
+
+plan skip_all => 't/cgi-bin/not-modified.pl' unless -x 't/cgi-bin/not-modified.pl';
+
+{
+  use Mojolicious::Lite;
+  plugin CGI => [ '/not-modified' => 't/cgi-bin/not-modified.pl' ];
+}
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/not-modified' => {'If-None-Match' => 'ABC'})
+    ->status_is(304)
+    ->header_is('X-Test' => 'if-none-match seen: ABC');
+
+done_testing;

--- a/t/nph-borked.t
+++ b/t/nph-borked.t
@@ -1,0 +1,19 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::Mojo;
+
+plan skip_all => 't/cgi-bin/nph-borked.pl' unless -x 't/cgi-bin/nph-borked.pl';
+
+{
+  use Mojolicious::Lite;
+  plugin CGI => [ '/nph-borked' => 't/cgi-bin/nph-borked.pl' ];
+}
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/nph-borked', {} )
+  ->status_is(403)
+  ->content_like(qr'This is the borked paywall');
+
+done_testing;

--- a/t/nph.t
+++ b/t/nph.t
@@ -1,0 +1,19 @@
+use warnings;
+use strict;
+use Test::More;
+use Test::Mojo;
+
+plan skip_all => 't/cgi-bin/nph.pl' unless -x 't/cgi-bin/nph.pl';
+
+{
+  use Mojolicious::Lite;
+  plugin CGI => [ '/nph' => 't/cgi-bin/nph.pl' ];
+}
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/nph', {} )
+  ->status_is(403)
+  ->content_like(qr'This is the paywall');
+
+done_testing;


### PR DESCRIPTION
I'm using Mojolicious::Plugin::CGI to run [Oddmuse](https://github.com/kensanata/oddmuse). This is a CGI script that was originally written with mod_perl in mind. Thus, in order to take advantage of the CGI plugin, I needed to make an addition: the plugin config now accepts a *run* parameter with a code ref. If this parameter is given, the plugin will no longer exec the script and just call the code ref and exit. The plugin user must make sure to require the code in the *before* hook for it all to work.

Once I got this working, I found that I wasn't getting the correct status codes as I was running the wiki. For one, the Status header Oddmuse was emitting wasn't being used. Once this worked for both non-parsed headers and CGI responses, I also found that the **If-Not-Modified** header wasn't being added to the environment, so I did that as well.

The tests (without setting TEST_MORBO) still pass, but I haven't written any additional tests to prove that my additions also work as intended. I'd be willing to do that, however, if you're interested in adding this code to Mojolicious::Plugin::CGI.
