### PR TITLE
Use the recurring waitpid event to reap slow kids.

### DIFF
--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -172,6 +172,7 @@ sub _run {
         while $args->{pids}{$pid}
         and kill 0, $pid
         and $GUARD--;
+      $defaults->{pids}{$pid} = $args->{pids}{$pid} if kill 0, $pid;
       return $c->finish if $c->res->code;
       return $c->render(text => "Could not run CGI script ($?, $!).\n", status => 500);
     },


### PR DESCRIPTION
Noticed a few zombies hanging around because waitpid() was not reaping child processes (seems they are slow to exit after STDOUT closes).  

The recurring waitpid event seems like a good place to always make sure that zombie child processes are cleaned up.  Maybe you have a better solution/idea.

Unfortunately I could not figure out a way to build a test that would trigger this condition.