### PR TITLE
Reaping slow kids with test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@
 /Makefile.old
 *.old
 *.swp
-~$
+*~
 /Mojolicious-Plugin-CGI*tar.gz
 t/cgi-bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ perl:
 env:
   - "HARNESS_OPTIONS=j1 TEST_POD=1 TEST_MORBO=1 TEST_PIPES=1"
 install:
-  - "cpanm -n Test::Pod Test::Pod::Coverage Parallel::ForkManager"
+  - "cpanm -n Test::Pod Test::Pod::Coverage Parallel::ForkManager Proc::ProcessTable"
   - "cpanm -n --installdeps ."
 notifications:
   email: false

--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -172,6 +172,7 @@ sub _run {
         while $args->{pids}{$pid}
         and kill 0, $pid
         and $GUARD--;
+      $defaults->{pids}{$pid} = $args->{pids}{$pid} if kill 0, $pid;
       return $c->finish if $c->res->code;
       return $c->render(text => "Could not run CGI script ($?, $!).\n", status => 500);
     },

--- a/t/run.t
+++ b/t/run.t
@@ -1,0 +1,19 @@
+use t::Helper;
+
+use Mojolicious::Lite;
+
+plugin CGI => {
+  route => '/',
+  run => sub {
+    print "HTTP/1.1 200 OK\r\n";
+    print "Content-Type: text/html; charset=ISO-8859-1\r\n";
+    print "\r\n";
+    print "<body><p>Hi!\n";
+  },
+};
+
+my $t = Test::Mojo->new;
+
+$t->get_ok('/')->status_is(200)->content_like(qr/Hi!/);
+
+done_testing;

--- a/t/zombies.t
+++ b/t/zombies.t
@@ -33,6 +33,7 @@ plugin Config => {
 
 plugin CGI => {
   route => '/',
+  script => "$script", # this is required to run the test for 0.26
   run => sub {
     print "HTTP/1.1 200 OK\r\n";
     print "Content-Type: text/text; charset=ISO-8859-1\r\n";

--- a/t/zombies.t
+++ b/t/zombies.t
@@ -1,0 +1,85 @@
+use Mojo::Base -strict;
+
+use Test::More;
+
+use File::Spec::Functions 'catfile';
+use File::Temp 'tempdir';
+use File::Which;
+use FindBin;
+
+use IO::Socket::INET;
+use Mojo::IOLoop::Server;
+use Mojo::Server::Hypnotoad;
+use Mojo::UserAgent;
+use Mojo::Util qw(slurp spurt);
+
+# Prepare script
+my $dir = tempdir CLEANUP => 1;
+my $script = catfile $dir, 'myapp.pl';
+my $port  = Mojo::IOLoop::Server->generate_port;
+
+spurt <<EOF, $script;
+use lib "$FindBin::Bin/../lib";
+use Mojolicious::Lite;
+
+plugin Config => {
+  default => {
+    hypnotoad => {
+      inactivity_timeout => 3,
+      listen => ['http://127.0.0.1:$port'],
+      workers => 4
+    }
+  }
+};
+
+plugin CGI => {
+  route => '/',
+  run => sub {
+    print "HTTP/1.1 200 OK\r\n";
+    print "Content-Type: text/text; charset=ISO-8859-1\r\n";
+    print "\r\n";
+    print "Hello CGI!\n";
+  },
+};
+
+app->start;
+EOF
+
+# Start server
+my $hypnotoad = which 'hypnotoad';
+open my $start, '-|', $^X, $hypnotoad, $script;
+sleep 1 while !_port($port);
+
+# Remember PID
+open my $file, '<', catfile($dir, 'hypnotoad.pid');
+my $pid = <$file>;
+chomp $pid;
+ok $pid, "PID $pid found";
+
+# Application is alive
+my $ua = Mojo::UserAgent->new;
+my $tx = $ua->get("http://127.0.0.1:$port/");
+is $tx->res->code, 200, 'right status';
+is $tx->res->body, "Hello CGI!\n", 'right content';
+
+# Hammer the server
+my $delay = Mojo::IOLoop->delay(
+  sub {
+    my $delay = shift;
+    for my $i (1 .. 100) {
+      $ua->get("http://127.0.0.1:$port/" => $delay->begin);
+    };
+  }
+)->wait();
+
+# Stop the server
+open my $stop, '-|', $^X, $hypnotoad, $script, '-s';
+sleep 1 while _port($port);
+
+# Checking Processes
+my $alive = kill 0 => $pid;
+is $alive, 0, "$pid is terminated";
+
+sub _port { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => shift) }
+
+done_testing();


### PR DESCRIPTION
This adds a test for zombies left behind when using `hypnotoad` and a slow drip of requests, and it incorporates the fix by @knox1000. This takes care of both #20 and #21.

I didn't look at the suggestion in the comments of #20.

This also adds a test that the ended up not helping me find the bug, but I decided to leave it in. This also changes a file pattern in .gitignore for Emacs users.