### PR TITLE
Early returns for destroyed transactions

### DIFF
--- a/lib/Mojolicious/Plugin/CGI.pm
+++ b/lib/Mojolicious/Plugin/CGI.pm
@@ -171,6 +171,7 @@ sub _run {
         and kill 0, $pid
         and $GUARD--;
       $defaults->{pids}{$pid} = $args->{pids}{$pid} if kill 0, $pid;
+      return unless $c->tx;
       return $c->finish if $c->res->code;
       return $c->render(text => "Could not run CGI script ($?, $!).\n", status => 500);
     }
@@ -198,6 +199,8 @@ sub _stdout_cb {
   return sub {
     my ($stream, $chunk) = @_;
     warn "[$log_key] >>> ($chunk)\n" if DEBUG;
+
+    return unless eval { $c->tx };
 
     # true if HTTP header has been written to client
     return $c->write($chunk) if $headers;


### PR DESCRIPTION
This is a tentative fix. I'm not quite sure how this is happening. I have a vague feeling that the CGI script calling exit under some conditions might be the cause of it. With a lot of web scraper activity, this might happen more often, depending on the nature of the script. This hypothesis is untested, however.

This prevents the following errors in the log:

- (in cleanup) Transaction already destroyed
- Mojo::Reactor::EV: I/O watcher failed: Transaction already destroyed
